### PR TITLE
Fix stable keys in NewsSection list

### DIFF
--- a/src/components/NewsSection/NewsSection.js
+++ b/src/components/NewsSection/NewsSection.js
@@ -103,7 +103,7 @@ export default function NewsSection({ newsProps }) {
     return (
       <TouchableOpacity
         className="mb-4 mx-4 space-y-1"
-        key={index}
+        key={item.url}
         onPress={() => handleClick(item)}
       >
         <View className="flex-row justify-start w-[100%]shadow-sm">
@@ -174,7 +174,7 @@ export default function NewsSection({ newsProps }) {
         scrollEnabled={false}
         data={newsProps}
         showsVerticalScrollIndicator={false}
-        keyExtractor={(item, index) => index.toString()}
+        keyExtractor={(item, index) => item.url || index.toString()}
         renderItem={renderItem}
       />
     </View>


### PR DESCRIPTION
## Summary
- use the article URL to assign stable keys for list items
- fall back to index only if the URL is missing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68656ee98e20832cae18810eec96845b